### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Authable
+# Authable [![Deps Status](https://beta.hexfaktor.org/badge/all/github/mustafaturan/authable.svg)](https://beta.hexfaktor.org/github/mustafaturan/authable)
 
 OAuth2 Provider implementation modules and helpers using `ecto` and `postgress` for any `elixir` application.
 


### PR DESCRIPTION
Hi there,

not sure if you are into badges, but I wanted to take a moment to pitch my latest project for the Elixir community:

  [![Deps Status](https://beta.hexfaktor.org/badge/all/github/mustafaturan/authable.svg)](https://beta.hexfaktor.org/github/mustafaturan/authable)

This badge shows you an analysis for your dependencies. Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. Just tell me what you think about this idea!