### PR TITLE
Fix typo in oauth2 module doc

### DIFF
--- a/lib/authable/oauth2.ex
+++ b/lib/authable/oauth2.ex
@@ -1,6 +1,6 @@
 defmodule Authable.OAuth2 do
   @moduledoc """
-  OAut2 authorization strategy router
+  OAuth2 authorization strategy router
   """
 
   import Ecto.Query, only: [from: 2]


### PR DESCRIPTION
Add the missing `h` in OAuth2