### PR TITLE
Fix typo in bearer module doc

### DIFF
--- a/lib/authable/authentications/bearer.ex
+++ b/lib/authable/authentications/bearer.ex
@@ -1,6 +1,6 @@
 defmodule Authable.Authentication.Bearer do
   @moduledoc """
-  Bearer authencation helper module, implements Authable.Authentication
+  Bearer authentication helper module, implements Authable.Authentication
   behaviour.
   """
 


### PR DESCRIPTION
Add missing `ti` in authentication.