### PR TITLE
Fix typo in header module doc

### DIFF
--- a/lib/authable/auth_strategies/header.ex
+++ b/lib/authable/auth_strategies/header.ex
@@ -1,7 +1,7 @@
 defmodule Authable.AuthStrategy.Header do
   @moduledoc """
   Authable Strategy implements behaviour Authable.Strategy to check 'header'
-  based authencations to find resource owner.
+  based authentications to find resource owner.
   """
 
   import Plug.Conn, only: [get_req_header: 2]


### PR DESCRIPTION
Add missing `ti` to authentications