### PR TITLE
Fix Refresh Tokens are basically never generated

### DIFF
--- a/lib/authable/grant_types/base.ex
+++ b/lib/authable/grant_types/base.ex
@@ -74,7 +74,7 @@ defmodule Authable.GrantType.Base do
     }
   end
 
-  defp put_refresh_token?(token_params, true),
+  defp put_refresh_token?(token_params, Authable.GrantType.RefreshToken),
     do: put_refresh_token(token_params)
   defp put_refresh_token?(token_params, _),
     do: token_params


### PR DESCRIPTION
This fixes an issue where refresh tokens are pretty much never generated. Details in the test case.

Tested with:

```
$ elixir --version
Erlang/OTP 19 [erts-8.2.2] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Elixir 1.4.2
```